### PR TITLE
Update tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 CRYSTAL_BIN ?= $(shell which crystal)
+SHARDS_BIN ?= $(shell which shards)
 SERVE_BIN ?= $(shell which crystalctags)
 PREFIX ?= /usr/local
 
 all: clean build
 
 build:
-	$(CRYSTAL_BIN) deps
-	$(CRYSTAL_BIN) build --release -o bin/crystalctags src/crystal_ctags/bootstrap.cr $(CRFLAGS)
+	$(SHARDS_BIN) install
+	$(SHARDS_BIN) build --release $(CRFLAGS)
 
 clean:
 	rm -f ./bin/crystalctags

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ let g:tagbar_type_crystal = {
 ## Contributors
 
 - [SuperPaintman](https://github.com/SuperPaintman) SuperPaintman - creator, maintainer
-
+- [anicholson](https://github.com/anicholson) Andy Nicholson - contributor
 
 --------------------------------------------------------------------------------
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,10 @@ version: 0.1.0
 authors:
   - SuperPaintman <SuperPaintmanDeveloper@gmail.com>
 
+targets:
+  crystalctags:
+    main: src/crystal_ctags/bootstrap.cr
+
 description: |
   Tool for generation ctags for Crystal
 


### PR DESCRIPTION
`crystal deps` is no longer a command, as it's been deprecated (& now removed) in favour of `shards`.